### PR TITLE
Fix exception when retrieving mixed data types

### DIFF
--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -164,11 +164,13 @@ class ExasolConnectionManager(SQLConnectionManager):
                 if len(rows) > 0 and isinstance(rows[0][idx], str):
                     if col[1] in ["DECIMAL", "BIGINT"]:
                         for rownum, row in enumerate(rows):
+                            if row[idx] is None: continue
                             tmp = list(row)
                             tmp[idx] = decimal.Decimal(row[idx])
                             rows[rownum] = tmp
                     elif col[1].startswith("TIMESTAMP"):
                         for rownum, row in enumerate(rows):
+                            if row[idx] is None: continue
                             tmp = list(row)
                             tmp[idx] = parser.parse(row[idx])
                             rows[rownum] = tmp

--- a/tests/functional/adapter/utils/test_mixed_type_retrieval.py
+++ b/tests/functional/adapter/utils/test_mixed_type_retrieval.py
@@ -1,0 +1,12 @@
+import pytest
+import decimal
+from dbt.tests.util import get_connection
+
+class TestMixedTypeRetrieval:
+    # A Decimal followed by a NULL used to raise an exception.
+    # Verify that it no longer does.
+    def test_decimal_followed_by_null(self,project):
+        sql = "select * from values 1.2, null"
+        with get_connection(project.adapter) as conn:
+            _, res = project.adapter.execute(sql, fetch=True)
+        assert res.rows.values() == ( ( decimal.Decimal('1.2'), ),( None, ) )


### PR DESCRIPTION
If the first row of a column returned from Exasol was a decimal type then the adapter would expect all subsequent rows to be decimal and if one of them happened to be NULL it would throw an exception:

"conversion from NoneType to Decimal is not supported"

This commit fixes that.