### PR TITLE
bugfix release 1.10.5

### DIFF
--- a/dbt/adapters/exasol/__version__.py
+++ b/dbt/adapters/exasol/__version__.py
@@ -1,6 +1,6 @@
 """dbt-exasol adapter version"""
 
-VERSION = "1.10.4"
+VERSION = "1.10.5"
 
 # dbt-core 1.11+ expects lowercase 'version' instead of 'VERSION'
 version = VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-exasol"
-version = "1.10.4"
+version = "1.10.5"
 description = "Adapter to dbt-core for warehouse Exasol"
 authors = [
   { name = "Torsten Glunde", email = "torsten.glunde@alligator-company.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "dbt-exasol"
-version = "1.10.4"
+version = "1.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "dbt-adapters" },


### PR DESCRIPTION
## Summary

Bugfix release v1.10.5 with the following changes since v1.10.4:

### Bug Fixes
- Fixed connection pool leak issue ensuring all threads have proper connections
- Fixed connection leak in _close_handle with atexit cleanup
- Improved connection handling and resource cleanup

### Improvements
- Refactored connection handling for better maintainability
- Multi-slot pooling implementation
- Updated relation rename/replace handling (now defaults like postgres)
- Simplified table and view materialization macros

### Dependencies
- Updated deepdiff 8.6.1 to 8.6.2
- Updated tornado 6.5.4 to 6.5.5
- Updated dbt-common 1.37.2 to 1.37.3
- Set pyexasol version >= 2 as minimum requirement

### Testing
- Added integration tests for connection pool leak prevention
- Improved test coverage reporting
- CI filter fixes