### PR TITLE
Release v1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,8 @@
 # Changelog
 
-## 1.12.1 — polish and bugfixes
+## 1.12.2 — bugfixes and documentation
 
-A maintenance release with no breaking changes. Completes the feature set
-announced in v1.12.0 with the last fixes and some usability improvements.
-
-### Added
-- `database` parameter in `profiles.yml` now defaults to `"DB"` (Exasol's
-  default database name), so projects that don't need a specific database can
-  omit it entirely.
-- TLS certificate parameter documented in the README for secure connections.
+A maintenance release containing bugfixes and documentation improvements.
 
 ### Changed
 - **`timestamp_format` is now documented as session-wide** ([#229](https://github.com/exasol/dbt-exasol/issues/229)).
@@ -22,6 +15,23 @@ announced in v1.12.0 with the last fixes and some usability improvements.
   states the scope and how to opt into the server default; the applied format
   is also emitted as a debug log line. No behaviour change — the default is
   unchanged and a breaking change is deferred to a major release.
+
+### Fixed
+- **Fixed schema quoting in cache lookup and unhandled relation database** ([#228](https://github.com/exasol/dbt-exasol/issues/228)).
+  In `exasol__list_relations_without_caching`, unquoted schema identifiers are now compared properly when `quoting: {schema: true}` is enabled, avoiding empty cache lookups that permanently disabled relation caching. Introduced `ExasolIncludePolicy` to prevent `list_None_<SCHEMA>` in logs while maintaining Exasol's database-omitted relation rendering.
+
+## 1.12.1 — polish and bugfixes
+
+A maintenance release with no breaking changes. Completes the feature set
+announced in v1.12.0 with the last fixes and some usability improvements.
+
+### Added
+- `database` parameter in `profiles.yml` now defaults to `"DB"` (Exasol's
+  default database name), so projects that don't need a specific database can
+  omit it entirely.
+- TLS certificate parameter documented in the README for secure connections.
+
+### Changed
 - The `exasol__create_schema` and `exasol__persist_docs` macro overrides have
   been removed: both had converged to be byte-identical to dbt-core's current
   `default__create_schema` / `default__persist_docs`. Dispatch now falls

--- a/dbt/adapters/exasol/__version__.py
+++ b/dbt/adapters/exasol/__version__.py
@@ -1,6 +1,6 @@
 """dbt-exasol adapter version"""
 
-VERSION = "1.12.1"
+VERSION = "1.12.2"
 
 # dbt-core 1.11+ expects lowercase 'version' instead of 'VERSION'
 version = VERSION

--- a/dbt/adapters/exasol/version.py
+++ b/dbt/adapters/exasol/version.py
@@ -10,6 +10,6 @@ If you need to change the version, do so in the pyproject.toml, e.g. by using
 
 MAJOR = 1
 MINOR = 12
-PATCH = 1
+PATCH = 2
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
 __version__ = VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-exasol"
-version = "1.12.1"
+version = "1.12.2"
 description = "Adapter to dbt-core for warehouse Exasol"
 authors = [
   { name = "Torsten Glunde", email = "torsten.glunde@alligator-company.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/d1/d5/9084bd0356b83c703
 
 [[package]]
 name = "dbt-exasol"
-version = "1.12.1"
+version = "1.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "dbt-adapters" },


### PR DESCRIPTION
## Summary

Prepares the **v1.12.2** release.

### Changes included in 1.12.2

1. **Fixed schema quoting cache & unhandled relation database ([#228](https://github.com/exasol/dbt-exasol/issues/228), [#230](https://github.com/exasol/dbt-exasol/pull/230))**
   - Fixed `exasol__list_relations_without_caching` to inspect the unquoted schema identifier (`schema.schema`) rather than string-interpolating the relation object, preventing quote characters from breaking schema matching and disabling the relation cache when `quoting: {schema: true}` is set.
   - Added `ExasolIncludePolicy(database=False)` on `ExasolRelation` so the database identifier is preserved in the cache/path key (avoiding `list_None_<SCHEMA>` logs) while omitting it from rendered SQL identifiers.

2. **Documented session-wide scope of `timestamp_format` ([#229](https://github.com/exasol/dbt-exasol/issues/229), [#231](https://github.com/exasol/dbt-exasol/pull/231))**
   - Clarified in documentation that `timestamp_format` is applied session-wide (`ALTER SESSION SET NLS_TIMESTAMP_FORMAT`), governing models, snapshots, and seeds.
   - Added debug logging when the session timestamp format is applied.

3. **Version bump & Changelog**
   - Bumped adapter version to `1.12.2` across `pyproject.toml`, `dbt/adapters/exasol/__version__.py`, `dbt/adapters/exasol/version.py`, and `uv.lock`.
   - Updated `CHANGELOG.md` with release notes for `1.12.2`.

---

## What to review

- **`CHANGELOG.md`**: Verify that the `1.12.2` section accurately summarizes the changes and fixes released in this version.
- **Version declarations**: Ensure consistency across `pyproject.toml`, `dbt/adapters/exasol/__version__.py`, `dbt/adapters/exasol/version.py`, and `uv.lock`.

## Verification

All validation suites pass cleanly:
- `nox -s format:check` — clean
- `nox -s lint:code lint:security lint:typing` — clean (9.62/10 rating, 0 security issues, 96 source files type checked)
- `nox -s test:unit` — 275 passed
- `nox -s changelog:updated` — success
- `nox -s version:check` — success